### PR TITLE
Fix logout token removal

### DIFF
--- a/src/app/store.js
+++ b/src/app/store.js
@@ -3,8 +3,6 @@ import { authApi } from '../modules/auth/authApi'
 import authReducer from '../modules/auth/authSlice'
 import { animalsApi } from '../modules/animals/animalsApi'
 
-middleware: getDefault => getDefault().concat(authApi.middleware, animalsApi.middleware)
-
 export default configureStore({
   reducer: {
     [authApi.reducerPath]: authApi.reducer,

--- a/src/modules/auth/logout.js
+++ b/src/modules/auth/logout.js
@@ -1,6 +1,6 @@
 export default function logout() {
-  localStorage.removeItem("token")
-  localStorage.removeItem("user")
-  localStorage.removeItem("roles")
-  window.location.href = "/login"
+  localStorage.removeItem('access_token')
+  localStorage.removeItem('user')
+  localStorage.removeItem('roles')
+  window.location.href = '/login'
 }


### PR DESCRIPTION
## Summary
- fix missing access_token removal when logging out
- remove stray middleware line from store configuration

## Testing
- `npm run lint` *(fails: 'useRef' defined but never used in AnimalForm.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68432de7f1c8833383ae78be5fa58c98