### PR TITLE
Add provider module CRUD

### DIFF
--- a/src/app/store.js
+++ b/src/app/store.js
@@ -2,13 +2,19 @@ import { configureStore } from '@reduxjs/toolkit'
 import { authApi } from '../modules/auth/authApi'
 import authReducer from '../modules/auth/authSlice'
 import { animalsApi } from '../modules/animals/animalsApi'
+import { providerApi } from '../modules/provider/providerApi'
 
 export default configureStore({
   reducer: {
     [authApi.reducerPath]: authApi.reducer,
     [animalsApi.reducerPath]: animalsApi.reducer,
+    [providerApi.reducerPath]: providerApi.reducer,
     auth: authReducer
   },
   middleware: (getDefault) =>
-    getDefault().concat(authApi.middleware, animalsApi.middleware)
+    getDefault().concat(
+      authApi.middleware,
+      animalsApi.middleware,
+      providerApi.middleware
+    )
 })

--- a/src/layouts/MainLayout.jsx
+++ b/src/layouts/MainLayout.jsx
@@ -16,7 +16,8 @@ const drawerWidth = 220
 
 const menu = [
   { label: 'Dashboard', path: '/', icon: <DashboardIcon /> },
-  { label: 'Animals', path: '/animals', icon: <PetsIcon /> }
+  { label: 'Animals', path: '/animals', icon: <PetsIcon /> },
+  { label: 'Providers', path: '/providers', icon: <PetsIcon /> }
 ]
 
 export default function MainLayout() {
@@ -25,6 +26,7 @@ export default function MainLayout() {
 const pageTitles = {
   '/': t('page.dashboard', 'Dashboard'),
   '/animals': t('page.animals', 'Animals'),
+  '/providers': t('page.providers', 'Providers'),
   '/users': t('page.users', 'Users'),
   // ajoute d'autres routes ici...
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -15,6 +15,7 @@
     "logout": "Logout",
     "language": "Language",
     "add_animal": "Add",
+    "add_provider": "Add",
     "edit": "Edit",
     "delete": "Delete"
 
@@ -23,7 +24,8 @@
     "not_found": "Page not found",
     "dashboard": "Dashboard",
     "animals": "Animals",
-    "users": "Users"
+    "users": "Users",
+    "providers": "Providers"
   },
     "roles": {
     "super_admin": "Super Admin",
@@ -60,6 +62,17 @@
   },
   "button": {
     "save": "Enregistrer"
+  },
+  "provider": {
+    "name": "Name",
+    "email": "Email",
+    "phone": "Phone",
+    "address": "Address",
+    "create_title": "New provider",
+    "edit_title": "Edit provider",
+    "saved": "Saved!",
+    "save_error": "Save error",
+    "not_found": "Provider not found"
   }
 }
   

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -31,10 +31,12 @@
   "page": {
   "dashboard": "Tableau de bord",
   "animals": "Animaux",
-  "users": "Utilisateurs"
+  "users": "Utilisateurs",
+  "providers": "Prestataires"
   },
   "button": {
     "add_animal": "Ajouter",
+    "add_provider": "Ajouter",
     "edit": "Éditer",
     "delete": "Supprimer"
   },
@@ -65,6 +67,17 @@
   },
   "button": {
     "save": "Enregistrer"
+  }
+  ,"provider": {
+    "name": "Nom",
+    "email": "Email",
+    "phone": "Téléphone",
+    "address": "Adresse",
+    "create_title": "Nouveau prestataire",
+    "edit_title": "Modifier le prestataire",
+    "saved": "Modifications enregistrées !",
+    "save_error": "Erreur lors de l'enregistrement",
+    "not_found": "Prestataire introuvable"
   }
 }
   

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -31,10 +31,12 @@
   "page": {
   "dashboard": "Dashboard",
   "animals": "Animali",
-  "users": "Utenti"
+  "users": "Utenti",
+  "providers": "Fornitori"
 },
   "button": {
     "add_animal": "Aggiungi",
+    "add_provider": "Aggiungi",
     "edit": "Modifica",
     "delete": "Elimina"
   },
@@ -65,6 +67,17 @@
   },
   "button": {
     "save": "Enregistrer"
+  },
+  "provider": {
+    "name": "Nome",
+    "email": "Email",
+    "phone": "Telefono",
+    "address": "Indirizzo",
+    "create_title": "Nuovo fornitore",
+    "edit_title": "Modifica fornitore",
+    "saved": "Salvato!",
+    "save_error": "Errore di salvataggio",
+    "not_found": "Fornitore non trovato"
   }
 }
   

--- a/src/modules/provider/providerApi.js
+++ b/src/modules/provider/providerApi.js
@@ -1,0 +1,57 @@
+import { createApi } from '@reduxjs/toolkit/query/react'
+import { baseQueryWithRefresh } from '../auth/authApi'
+
+export const providerApi = createApi({
+  reducerPath: 'providerApi',
+  baseQuery: baseQueryWithRefresh,
+  tagTypes: ['Provider'],
+  endpoints: (b) => ({
+    listProviders: b.query({
+      query: () => 'providers',
+      providesTags: ['Provider']
+    }),
+    getProvider: b.query({
+      query: (id) => `providers/${id}`
+    }),
+    addProvider: b.mutation({
+      query: (body) => ({ url: 'providers', method: 'POST', body }),
+      invalidatesTags: ['Provider']
+    }),
+    updateProvider: b.mutation({
+      query: ({ id, ...body }) => ({
+        url: `providers/${id}`,
+        method: 'PUT',
+        body,
+        ...(body instanceof FormData ? {} : { headers: { 'Content-Type': 'application/json' } })
+      }),
+      invalidatesTags: ['Provider']
+    }),
+    uploadImage: b.mutation({
+      query: ({ id, file }) => {
+        const formData = new FormData()
+        formData.append('image', file)
+        return {
+          url: `providers/${id}/image`,
+          method: 'POST',
+          body: formData
+        }
+      },
+      invalidatesTags: ['Provider']
+    }),
+    deleteProvider: b.mutation({
+      query: (id) => ({ url: `providers/${id}`, method: 'DELETE' }),
+      invalidatesTags: ['Provider']
+    })
+  })
+})
+
+export const {
+  useListProvidersQuery,
+  useGetProviderQuery,
+  useAddProviderMutation,
+  useUpdateProviderMutation,
+  useDeleteProviderMutation,
+  useUploadImageMutation: useUploadProviderImageMutation
+} = providerApi
+
+export { providerApi }

--- a/src/modules/provider/useProviderForm.js
+++ b/src/modules/provider/useProviderForm.js
@@ -1,0 +1,26 @@
+import { useNavigate } from 'react-router-dom'
+import {
+  useAddProviderMutation,
+  useUpdateProviderMutation,
+  useGetProviderQuery
+} from './providerApi'
+
+export default function useProviderForm(id) {
+  const { data } = useGetProviderQuery(id, { skip: !id })
+  const [addProvider, addStatus] = useAddProviderMutation()
+  const [updateProvider, updateStatus] = useUpdateProviderMutation()
+  const nav = useNavigate()
+
+  const submit = async (values) => {
+    if (id) {
+      await updateProvider({ id, ...values }).unwrap()
+    } else {
+      await addProvider(values).unwrap()
+    }
+    nav('/providers')
+  }
+
+  const loading = addStatus.isLoading || updateStatus.isLoading
+
+  return { data, submit, loading, addStatus, updateStatus }
+}

--- a/src/modules/provider/useProviders.js
+++ b/src/modules/provider/useProviders.js
@@ -1,0 +1,6 @@
+import { useListProvidersQuery } from './providerApi'
+
+export default function useProviders() {
+  const { data = [], isLoading, error, refetch } = useListProvidersQuery()
+  return { providers: data, isLoading, error, refetch }
+}

--- a/src/pages/provider/ProviderDetails.jsx
+++ b/src/pages/provider/ProviderDetails.jsx
@@ -1,0 +1,32 @@
+import { Box, Typography, Stack, Button } from '@mui/material'
+import { useNavigate, useParams } from 'react-router-dom'
+import { useGetProviderQuery } from '../../modules/provider/providerApi'
+import { useTranslation } from 'react-i18next'
+
+export default function ProviderDetails() {
+  const nav = useNavigate()
+  const { id } = useParams()
+  const { data, isLoading } = useGetProviderQuery(id)
+  const { t } = useTranslation()
+
+  if (isLoading) return <div>Loading...</div>
+  if (!data) return <div>{t('provider.not_found', 'Not found')}</div>
+
+  return (
+    <Box sx={{ maxWidth: 600, mx: 'auto' }}>
+      <Button variant="outlined" onClick={() => nav('/providers')} sx={{ mb: 2 }}>
+        {t('button.back', 'Back')}
+      </Button>
+
+      <Stack spacing={1} sx={{ background: '#fff', p: 3, borderRadius: 2 }}>
+        <Typography variant="h5" fontWeight={600}>{data.name}</Typography>
+        <Typography>{data.email}</Typography>
+        <Typography>{data.phone}</Typography>
+        <Typography>{data.address}</Typography>
+        <Button variant="contained" sx={{ mt: 2 }} onClick={() => nav(`/providers/${id}/edit`)}>
+          {t('button.edit', 'Edit')}
+        </Button>
+      </Stack>
+    </Box>
+  )
+}

--- a/src/pages/provider/ProviderForm.jsx
+++ b/src/pages/provider/ProviderForm.jsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import useProviderForm from '../../modules/provider/useProviderForm'
+import { TextField, Button, Stack, Box, Typography, CircularProgress, Alert } from '@mui/material'
+import { useParams } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import PhotoUploader from '../../components/PhotoUploader'
+import { useUploadProviderImageMutation } from '../../modules/provider/providerApi'
+
+export default function ProviderForm() {
+  const { id } = useParams()
+  const { data, submit, loading } = useProviderForm(id)
+  const { register, handleSubmit, reset, setValue, watch, formState } = useForm({ defaultValues: data })
+  const { t } = useTranslation()
+  const [feedback, setFeedback] = useState(null)
+  const [uploadImage] = useUploadProviderImageMutation()
+
+  React.useEffect(() => {
+    if (data) reset(data)
+  }, [data, reset])
+
+  const onSubmit = async (values) => {
+    setFeedback(null)
+    try {
+      await submit(values)
+      if (values.logo instanceof File || values.logo instanceof Blob) {
+        const res = await uploadImage({ id, file: values.logo }).unwrap()
+        if (res.logo) setValue('logo', res.logo)
+      }
+      setFeedback({ type: 'success', message: t('provider.saved', 'Saved!') })
+    } catch (err) {
+      setFeedback({ type: 'error', message: t('provider.save_error', 'Save error') })
+    }
+  }
+
+  return (
+    <Box
+      component="form"
+      onSubmit={handleSubmit(onSubmit)}
+      sx={{
+        maxWidth: 500,
+        mx: 'auto',
+        mt: 4,
+        bgcolor: '#fff',
+        p: 4,
+        borderRadius: 3,
+        boxShadow: 2,
+        minHeight: 400
+      }}
+      noValidate
+    >
+      <Stack spacing={3}>
+        <PhotoUploader
+          value={watch('logo') || data?.logo}
+          onChange={file => setValue('logo', file)}
+        />
+
+        <Typography variant="h5" align="center" fontWeight={600} sx={{ mt: 1, mb: 1 }}>
+          {id ? t('provider.edit_title', 'Edit provider') : t('provider.create_title', 'New provider')}
+        </Typography>
+
+        <TextField
+          label={t('provider.name', 'Name')}
+          {...register('name', { required: true })}
+          fullWidth
+          InputLabelProps={{ shrink: true }}
+          error={!!formState.errors.name}
+        />
+        <TextField
+          label={t('provider.email', 'Email')}
+          {...register('email')}
+          fullWidth
+          type="email"
+        />
+        <TextField label={t('provider.phone', 'Phone')} {...register('phone')} fullWidth />
+        <TextField label={t('provider.address', 'Address')} {...register('address')} fullWidth />
+
+        {feedback && <Alert severity={feedback.type}>{feedback.message}</Alert>}
+
+        <Button variant="contained" size="large" type="submit" disabled={loading} sx={{ fontWeight: 600 }}>
+          {loading ? <><CircularProgress size={24} sx={{ color: 'white', mr: 2 }} />{t('button.saving', 'Saving...')}</> : t('button.save', 'Save')}
+        </Button>
+      </Stack>
+    </Box>
+  )
+}

--- a/src/pages/provider/ProvidersList.jsx
+++ b/src/pages/provider/ProvidersList.jsx
@@ -1,0 +1,92 @@
+import useProviders from '../../modules/provider/useProviders'
+import { useDeleteProviderMutation } from '../../modules/provider/providerApi'
+import { DataGrid } from '@mui/x-data-grid'
+import { Button, Stack, Box, IconButton } from '@mui/material'
+import { useNavigate } from 'react-router-dom'
+import AddIcon from '@mui/icons-material/Add'
+import EditIcon from '@mui/icons-material/Edit'
+import DeleteIcon from '@mui/icons-material/Delete'
+import VisibilityIcon from '@mui/icons-material/Visibility'
+import { useTranslation } from 'react-i18next'
+
+export default function ProvidersList() {
+  const { providers, isLoading, refetch } = useProviders()
+  const [deleteProvider] = useDeleteProviderMutation()
+  const nav = useNavigate()
+  const { t } = useTranslation()
+
+  const columns = [
+    { field: 'id', headerName: 'ID', width: 70 },
+    { field: 'name', headerName: t('provider.name', 'Name'), flex: 1 },
+    { field: 'email', headerName: t('provider.email', 'Email'), flex: 1 },
+    { field: 'phone', headerName: t('provider.phone', 'Phone'), flex: 1 },
+    {
+      field: 'actions',
+      headerName: t('table.actions', 'Actions'),
+      width: 150,
+      renderCell: (params) => (
+        <Box>
+          <IconButton color="info" onClick={() => nav(`/providers/${params.row.id}`)}>
+            <VisibilityIcon />
+          </IconButton>
+          <IconButton color="primary" onClick={() => nav(`/providers/${params.row.id}/edit`)}>
+            <EditIcon />
+          </IconButton>
+          <IconButton
+            color="error"
+            onClick={async () => {
+              if (window.confirm(t('confirm.delete', 'Supprimer ?'))) {
+                await deleteProvider(params.row.id)
+                refetch()
+              }
+            }}
+          >
+            <DeleteIcon />
+          </IconButton>
+        </Box>
+      )
+    }
+  ]
+
+  return (
+    <Stack spacing={2}>
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 1 }}>
+        <Button
+          variant="contained"
+          color="primary"
+          startIcon={<AddIcon />}
+          sx={{ borderRadius: 3, fontWeight: 600, fontSize: 16, px: 3 }}
+          onClick={() => nav('/providers/create')}
+        >
+          {t('button.add_provider', 'Add')}
+        </Button>
+      </Box>
+      <Box
+        sx={{
+          height: 500,
+          background: '#fff',
+          borderRadius: 2,
+          p: 2,
+          width: '100%',
+          minWidth: 0,
+          overflowX: 'auto'
+        }}
+      >
+        <DataGrid
+          rows={providers}
+          columns={columns}
+          loading={isLoading}
+          pageSize={10}
+          rowsPerPageOptions={[5, 10, 20, 100]}
+          getRowId={row => row.id}
+          disableSelectionOnClick
+          sx={{
+            width: '100%',
+            minWidth: 600,
+            '& .MuiDataGrid-cell': { whiteSpace: 'normal', wordBreak: 'break-word' }
+          }}
+        />
+      </Box>
+    </Stack>
+  )
+}

--- a/src/routes/adminRoutes.jsx
+++ b/src/routes/adminRoutes.jsx
@@ -3,10 +3,13 @@ import MainLayout   from '../layouts/MainLayout'
 import RequireAuth  from '../modules/auth/RequireAuth'
 import RequireRole  from '../modules/auth/RequireRole'
 import Dashboard    from '../pages/Dashboard'
-import UsersList    from '../pages/UsersList'
+import UsersList      from '../pages/UsersList'
 import AnimalsList    from '../pages/animal/AnimalsList'
-import AnimalForm from '../pages/animal/AnimalForm'
-import AnimalDetails from '../pages/animal/AnimalDetails'
+import AnimalForm     from '../pages/animal/AnimalForm'
+import AnimalDetails  from '../pages/animal/AnimalDetails'
+import ProvidersList  from '../pages/provider/ProvidersList'
+import ProviderForm   from '../pages/provider/ProviderForm'
+import ProviderDetails from '../pages/provider/ProviderDetails'
 
 
 
@@ -31,6 +34,15 @@ export default [
           { path: 'create', element: <AnimalForm /> },
           { path: ':id/edit', element: <AnimalForm /> },
           { path: ':id', element: <AnimalDetails /> },
+        ]
+      },
+      {
+        path: 'providers',
+        children: [
+          { index: true, element: <ProvidersList /> },
+          { path: 'create', element: <ProviderForm /> },
+          { path: ':id/edit', element: <ProviderForm /> },
+          { path: ':id', element: <ProviderDetails /> }
         ]
       },
       {


### PR DESCRIPTION
## Summary
- implement providerApi RTK query endpoints
- create hooks for provider data and form handling
- add provider pages (list/form/details)
- integrate provider module into routes, store, and layout menu
- extend i18n files with provider labels

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68433c11715083338216b3415f924590