### PR TITLE
Add roles & permissions management

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Roles & Permissions module
+
+This project now includes an admin module to manage roles and permissions. It provides CRUD pages for roles and permissions as well as an interface to assign permissions to a role. Users can be assigned multiple roles from the user form.

--- a/src/app/store.js
+++ b/src/app/store.js
@@ -4,6 +4,7 @@ import authReducer from '../modules/auth/authSlice'
 import { animalsApi } from '../modules/animals/animalsApi'
 import { usersApi } from '../modules/users/usersApi'
 import { providerApi } from '../modules/provider/providerApi'
+import { rolesApi } from '../modules/roles/rolesApi'
 
 export default configureStore({
   reducer: {
@@ -11,6 +12,7 @@ export default configureStore({
     [animalsApi.reducerPath]: animalsApi.reducer,
     [usersApi.reducerPath]: usersApi.reducer,
     [providerApi.reducerPath]: providerApi.reducer,
+    [rolesApi.reducerPath]: rolesApi.reducer,
     auth: authReducer
   },
   middleware: (getDefault) =>
@@ -18,4 +20,5 @@ export default configureStore({
       .concat(authApi.middleware, animalsApi.middleware)
       .concat(usersApi.middleware)
       .concat(providerApi.middleware)
+      .concat(rolesApi.middleware)
 })

--- a/src/layouts/MainLayout.jsx
+++ b/src/layouts/MainLayout.jsx
@@ -20,7 +20,9 @@ const menu = [
   { label: 'Dashboard', path: '/', icon: <DashboardIcon /> },
   { label: 'Animals', path: '/animals', icon: <PetsIcon /> },
   { label: 'Users', path: '/users', icon: <PeopleIcon /> },
-  { label: 'Providers', path: '/providers', icon: <BusinessIcon /> }
+  { label: 'Providers', path: '/providers', icon: <BusinessIcon /> },
+  { label: 'Roles', path: '/roles', icon: <PeopleIcon /> },
+  { label: 'Permissions', path: '/permissions', icon: <BusinessIcon /> }
 ]
 
 
@@ -32,6 +34,8 @@ const pageTitles = {
   '/animals': t('page.animals', 'Animals'),
   '/providers': t('page.providers', 'Providers'),
   '/users': t('page.users', 'Users'),
+  '/roles': t('page.roles', 'Roles'),
+  '/permissions': t('page.permissions', 'Permissions'),
   // ajoute d'autres routes ici...
 }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -16,6 +16,8 @@
     "language": "Language",
     "add_animal": "Add",
     "add_provider": "Add",
+    "add_role": "Add",
+    "add_permission": "Add",
     "edit": "Edit",
     "delete": "Delete"
 
@@ -25,7 +27,9 @@
     "dashboard": "Dashboard",
     "animals": "Animals",
     "users": "Users",
-    "providers": "Providers"
+    "providers": "Providers",
+    "roles": "Roles",
+    "permissions": "Permissions"
   },
     "roles": {
     "super_admin": "Super Admin",
@@ -73,6 +77,20 @@
     "saved": "Saved!",
     "save_error": "Save error",
     "not_found": "Provider not found"
+  },
+  "role": {
+    "create_title": "New role",
+    "edit_title": "Edit role",
+    "saved": "Saved!",
+    "save_error": "Save error",
+    "name": "Name",
+    "not_found": "Role not found"
+  },
+  "permission": {
+    "create_title": "New permission",
+    "edit_title": "Edit permission",
+    "save_error": "Save error",
+    "name": "Name"
   }
 }
   

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -32,11 +32,15 @@
   "dashboard": "Tableau de bord",
   "animals": "Animaux",
   "users": "Utilisateurs",
-  "providers": "Prestataires"
+  "providers": "Prestataires",
+  "roles": "Rôles",
+  "permissions": "Permissions"
   },
   "button": {
     "add_animal": "Ajouter",
     "add_provider": "Ajouter",
+    "add_role": "Ajouter",
+    "add_permission": "Ajouter",
     "edit": "Éditer",
     "delete": "Supprimer"
   },
@@ -78,6 +82,20 @@
     "saved": "Modifications enregistrées !",
     "save_error": "Erreur lors de l'enregistrement",
     "not_found": "Prestataire introuvable"
+  },
+  "role": {
+    "create_title": "Nouveau rôle",
+    "edit_title": "Modifier le rôle",
+    "saved": "Modifications enregistrées !",
+    "save_error": "Erreur lors de l'enregistrement",
+    "name": "Nom",
+    "not_found": "Rôle introuvable"
+  },
+  "permission": {
+    "create_title": "Nouvelle permission",
+    "edit_title": "Modifier la permission",
+    "save_error": "Erreur lors de l'enregistrement",
+    "name": "Nom"
   }
 }
   

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -32,11 +32,15 @@
   "dashboard": "Dashboard",
   "animals": "Animali",
   "users": "Utenti",
-  "providers": "Fornitori"
+  "providers": "Fornitori",
+  "roles": "Ruoli",
+  "permissions": "Permessi"
 },
   "button": {
     "add_animal": "Aggiungi",
     "add_provider": "Aggiungi",
+    "add_role": "Aggiungi",
+    "add_permission": "Aggiungi",
     "edit": "Modifica",
     "delete": "Elimina"
   },
@@ -78,6 +82,20 @@
     "saved": "Salvato!",
     "save_error": "Errore di salvataggio",
     "not_found": "Fornitore non trovato"
+  },
+  "role": {
+    "create_title": "Nuovo ruolo",
+    "edit_title": "Modifica ruolo",
+    "saved": "Salvato!",
+    "save_error": "Errore di salvataggio",
+    "name": "Nome",
+    "not_found": "Ruolo non trovato"
+  },
+  "permission": {
+    "create_title": "Nuovo permesso",
+    "edit_title": "Modifica permesso",
+    "save_error": "Errore di salvataggio",
+    "name": "Nome"
   }
 }
   

--- a/src/modules/roles/rolesApi.js
+++ b/src/modules/roles/rolesApi.js
@@ -1,0 +1,75 @@
+import { createApi } from '@reduxjs/toolkit/query/react'
+import { baseQueryWithRefresh } from '../auth/authApi'
+
+export const rolesApi = createApi({
+  reducerPath: 'rolesApi',
+  baseQuery: baseQueryWithRefresh,
+  tagTypes: ['Role', 'Permission'],
+  endpoints: (b) => ({
+    listRoles: b.query({
+      query: () => 'roles',
+      providesTags: ['Role']
+    }),
+    getRole: b.query({
+      query: (id) => `roles/${id}`,
+      providesTags: (r, e, id) => [{ type: 'Role', id }]
+    }),
+    addRole: b.mutation({
+      query: (body) => ({ url: 'roles', method: 'POST', body }),
+      invalidatesTags: ['Role']
+    }),
+    updateRole: b.mutation({
+      query: ({ id, ...body }) => ({ url: `roles/${id}`, method: 'PUT', body }),
+      invalidatesTags: ['Role']
+    }),
+    deleteRole: b.mutation({
+      query: (id) => ({ url: `roles/${id}`, method: 'DELETE' }),
+      invalidatesTags: ['Role']
+    }),
+    listPermissions: b.query({
+      query: () => 'permissions',
+      providesTags: ['Permission']
+    }),
+    addPermission: b.mutation({
+      query: (body) => ({ url: 'permissions', method: 'POST', body }),
+      invalidatesTags: ['Permission']
+    }),
+    updatePermission: b.mutation({
+      query: ({ id, ...body }) => ({ url: `permissions/${id}`, method: 'PUT', body }),
+      invalidatesTags: ['Permission']
+    }),
+    deletePermission: b.mutation({
+      query: (id) => ({ url: `permissions/${id}`, method: 'DELETE' }),
+      invalidatesTags: ['Permission']
+    }),
+    assignPermission: b.mutation({
+      query: ({ roleId, permissionId }) => ({
+        url: `roles/${roleId}/permissions`,
+        method: 'POST',
+        body: { permissionId }
+      }),
+      invalidatesTags: (r, e, { roleId }) => [{ type: 'Role', id: roleId }]
+    }),
+    removePermission: b.mutation({
+      query: ({ roleId, permissionId }) => ({
+        url: `roles/${roleId}/permissions/${permissionId}`,
+        method: 'DELETE'
+      }),
+      invalidatesTags: (r, e, { roleId }) => [{ type: 'Role', id: roleId }]
+    })
+  })
+})
+
+export const {
+  useListRolesQuery,
+  useGetRoleQuery,
+  useAddRoleMutation,
+  useUpdateRoleMutation,
+  useDeleteRoleMutation,
+  useListPermissionsQuery,
+  useAddPermissionMutation,
+  useUpdatePermissionMutation,
+  useDeletePermissionMutation,
+  useAssignPermissionMutation,
+  useRemovePermissionMutation
+} = rolesApi

--- a/src/modules/roles/usePermissions.js
+++ b/src/modules/roles/usePermissions.js
@@ -1,0 +1,6 @@
+import { useListPermissionsQuery } from './rolesApi'
+
+export default function usePermissions() {
+  const { data = [], isLoading, error, refetch } = useListPermissionsQuery()
+  return { permissions: data, isLoading, error, refetch }
+}

--- a/src/modules/roles/useRoleForm.js
+++ b/src/modules/roles/useRoleForm.js
@@ -1,0 +1,24 @@
+import { useAddRoleMutation, useUpdateRoleMutation, useGetRoleQuery } from './rolesApi'
+import { useNavigate } from 'react-router-dom'
+
+export default function useRoleForm(id) {
+  const { data } = useGetRoleQuery(id, { skip: !id })
+  const [addRole, addStatus] = useAddRoleMutation()
+  const [updateRole, updateStatus] = useUpdateRoleMutation()
+  const nav = useNavigate()
+
+  const submit = async (values) => {
+    let savedId = id
+    if (id) {
+      await updateRole({ id, ...values }).unwrap()
+    } else {
+      const res = await addRole(values).unwrap()
+      savedId = res?.id || res?.role?.id
+    }
+    nav(`/roles/${savedId}`)
+  }
+
+  const loading = addStatus.isLoading || updateStatus.isLoading
+
+  return { data, submit, loading, addStatus, updateStatus }
+}

--- a/src/modules/roles/useRoles.js
+++ b/src/modules/roles/useRoles.js
@@ -1,0 +1,6 @@
+import { useListRolesQuery } from './rolesApi'
+
+export default function useRoles() {
+  const { data = [], isLoading, error, refetch } = useListRolesQuery()
+  return { roles: data, isLoading, error, refetch }
+}

--- a/src/pages/roles/PermissionForm.jsx
+++ b/src/pages/roles/PermissionForm.jsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { useAddPermissionMutation, useUpdatePermissionMutation, useListPermissionsQuery } from '../../modules/roles/rolesApi'
+import { TextField, Button, Stack, Box, Typography, CircularProgress, Alert } from '@mui/material'
+import { useParams, useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+
+export default function PermissionForm() {
+  const { id } = useParams()
+  const nav = useNavigate()
+  const { data } = useListPermissionsQuery(undefined, { selectFromResult: ({ data }) => ({ data: data?.find(p => p.id === Number(id)) }) })
+  const [addPermission, addStatus] = useAddPermissionMutation()
+  const [updatePermission, updateStatus] = useUpdatePermissionMutation()
+  const { register, handleSubmit, reset, formState } = useForm({ defaultValues: data })
+  const { t } = useTranslation()
+  const [feedback, setFeedback] = useState(null)
+
+  React.useEffect(() => { if (data) reset(data) }, [data, reset])
+
+  const onSubmit = async (values) => {
+    setFeedback(null)
+    try {
+      if (id) await updatePermission({ id, ...values }).unwrap()
+      else await addPermission(values).unwrap()
+      nav('/permissions')
+    } catch (err) {
+      setFeedback({ type: 'error', message: t('permission.save_error', 'Save error') })
+    }
+  }
+
+  const loading = addStatus.isLoading || updateStatus.isLoading
+
+  return (
+    <Box component="form" onSubmit={handleSubmit(onSubmit)}
+      sx={{ maxWidth: 400, mx: 'auto', mt: 4, bgcolor: '#fff', p: 4, borderRadius: 3, boxShadow: 2 }}
+      noValidate
+    >
+      <Stack spacing={3}>
+        <Typography variant="h5" align="center" fontWeight={600}>
+          {id ? t('permission.edit_title', 'Edit permission') : t('permission.create_title', 'New permission')}
+        </Typography>
+        <TextField
+          label={t('permission.name', 'Name')}
+          {...register('name', { required: true })}
+          fullWidth
+          InputLabelProps={{ shrink: true }}
+          error={!!formState.errors.name}
+        />
+        {feedback && <Alert severity={feedback.type}>{feedback.message}</Alert>}
+        <Button variant="contained" size="large" type="submit" disabled={loading} sx={{ fontWeight: 600 }}>
+          {loading ? <><CircularProgress size={24} sx={{ color: 'white', mr: 2 }} />{t('button.saving', 'Saving...')}</> : t('button.save', 'Save')}
+        </Button>
+      </Stack>
+    </Box>
+  )
+}

--- a/src/pages/roles/PermissionsList.jsx
+++ b/src/pages/roles/PermissionsList.jsx
@@ -1,0 +1,86 @@
+import usePermissions from '../../modules/roles/usePermissions'
+import { useDeletePermissionMutation } from '../../modules/roles/rolesApi'
+import { DataGrid } from '@mui/x-data-grid'
+import { Button, Stack, Box, IconButton } from '@mui/material'
+import { useNavigate } from 'react-router-dom'
+import AddIcon from '@mui/icons-material/Add'
+import EditIcon from '@mui/icons-material/Edit'
+import DeleteIcon from '@mui/icons-material/Delete'
+import { useTranslation } from 'react-i18next'
+
+export default function PermissionsList () {
+  const { permissions, isLoading, refetch } = usePermissions()
+  const [deletePermission] = useDeletePermissionMutation()
+  const nav = useNavigate()
+  const { t } = useTranslation()
+
+  const columns = [
+    { field: 'id', headerName: 'ID', width: 70 },
+    { field: 'name', headerName: t('permission.name', 'Name'), flex: 1 },
+    {
+      field: 'actions',
+      headerName: t('table.actions', 'Actions'),
+      width: 150,
+      renderCell: (params) => (
+        <Box>
+          <IconButton color="primary" onClick={() => nav(`/permissions/${params.row.id}/edit`)}>
+            <EditIcon />
+          </IconButton>
+          <IconButton
+            color="error"
+            onClick={async () => {
+              if (window.confirm(t('confirm.delete', 'Supprimer ?'))) {
+                await deletePermission(params.row.id)
+                refetch()
+              }
+            }}
+          >
+            <DeleteIcon />
+          </IconButton>
+        </Box>
+      )
+    }
+  ]
+
+  return (
+    <Stack spacing={2}>
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 1 }}>
+        <Button
+          variant="contained"
+          color="primary"
+          startIcon={<AddIcon />}
+          sx={{ borderRadius: 3, fontWeight: 600, fontSize: 16, px: 3 }}
+          onClick={() => nav('/permissions/create')}
+        >
+          {t('button.add_permission', 'Add')}
+        </Button>
+      </Box>
+      <Box
+        sx={{
+          height: 500,
+          background: '#fff',
+          borderRadius: 2,
+          p: 2,
+          width: '100%',
+          minWidth: 0,
+          overflowX: 'auto'
+        }}
+      >
+        <DataGrid
+          rows={permissions}
+          columns={columns}
+          loading={isLoading}
+          pageSize={10}
+          rowsPerPageOptions={[5, 10, 20, 100]}
+          getRowId={row => row.id}
+          disableSelectionOnClick
+          sx={{
+            width: '100%',
+            minWidth: 600,
+            '& .MuiDataGrid-cell': { whiteSpace: 'normal', wordBreak: 'break-word' }
+          }}
+        />
+      </Box>
+    </Stack>
+  )
+}

--- a/src/pages/roles/RoleDetails.jsx
+++ b/src/pages/roles/RoleDetails.jsx
@@ -1,0 +1,43 @@
+import { Box, Typography, Stack, FormControlLabel, Switch, Button } from '@mui/material'
+import { useParams, useNavigate } from 'react-router-dom'
+import { useGetRoleQuery, useListPermissionsQuery, useAssignPermissionMutation, useRemovePermissionMutation } from '../../modules/roles/rolesApi'
+import { useTranslation } from 'react-i18next'
+
+export default function RoleDetails() {
+  const { id } = useParams()
+  const nav = useNavigate()
+  const { t } = useTranslation()
+  const { data: role, isLoading } = useGetRoleQuery(id)
+  const { permissions = [] } = useListPermissionsQuery(undefined, { selectFromResult: ({ data }) => ({ permissions: data }) })
+  const [assign] = useAssignPermissionMutation()
+  const [remove] = useRemovePermissionMutation()
+
+  if (isLoading) return <div>Loading...</div>
+  if (!role) return <div>{t('role.not_found', 'Role not found')}</div>
+
+  const toggle = async (permId, checked) => {
+    if (checked) await assign({ roleId: id, permissionId: permId })
+    else await remove({ roleId: id, permissionId: permId })
+  }
+
+  return (
+    <Box sx={{ maxWidth: 600, mx: 'auto' }}>
+      <Typography variant="h4" fontWeight={700} sx={{ mb: 2 }}>{role.name}</Typography>
+      <Stack spacing={1}>
+        {permissions.map(p => (
+          <FormControlLabel
+            key={p.id}
+            control={<Switch
+              checked={role.permissions?.includes(p.name)}
+              onChange={e => toggle(p.id, e.target.checked)}
+            />}
+            label={p.name}
+          />
+        ))}
+      </Stack>
+      <Button sx={{ mt: 3 }} variant="contained" onClick={() => nav(`/roles/${id}/edit`)}>
+        {t('button.edit', 'Edit')}
+      </Button>
+    </Box>
+  )
+}

--- a/src/pages/roles/RoleForm.jsx
+++ b/src/pages/roles/RoleForm.jsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import useRoleForm from '../../modules/roles/useRoleForm'
+import { TextField, Button, Stack, Box, Typography, CircularProgress, Alert } from '@mui/material'
+import { useParams } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+
+export default function RoleForm() {
+  const { id } = useParams()
+  const { data, submit, loading } = useRoleForm(id)
+  const { register, handleSubmit, reset, formState } = useForm({ defaultValues: data })
+  const { t } = useTranslation()
+  const [feedback, setFeedback] = useState(null)
+
+  React.useEffect(() => { if (data) reset(data) }, [data, reset])
+
+  const onSubmit = async (values) => {
+    setFeedback(null)
+    try {
+      await submit(values)
+      setFeedback({ type: 'success', message: t('role.saved', 'Saved!') })
+    } catch (err) {
+      setFeedback({ type: 'error', message: t('role.save_error', 'Save error') })
+    }
+  }
+
+  return (
+    <Box component="form" onSubmit={handleSubmit(onSubmit)}
+      sx={{ maxWidth: 400, mx: 'auto', mt: 4, bgcolor: '#fff', p: 4, borderRadius: 3, boxShadow: 2 }}
+      noValidate
+    >
+      <Stack spacing={3}>
+        <Typography variant="h5" align="center" fontWeight={600}>
+          {id ? t('role.edit_title', 'Edit role') : t('role.create_title', 'New role')}
+        </Typography>
+        <TextField
+          label={t('role.name', 'Name')}
+          {...register('name', { required: true })}
+          fullWidth
+          InputLabelProps={{ shrink: true }}
+          error={!!formState.errors.name}
+        />
+        {feedback && <Alert severity={feedback.type}>{feedback.message}</Alert>}
+        <Button variant="contained" size="large" type="submit" disabled={loading} sx={{ fontWeight: 600 }}>
+          {loading ? <><CircularProgress size={24} sx={{ color: 'white', mr: 2 }} />{t('button.saving', 'Saving...')}</> : t('button.save', 'Save')}
+        </Button>
+      </Stack>
+    </Box>
+  )
+}

--- a/src/pages/roles/RolesList.jsx
+++ b/src/pages/roles/RolesList.jsx
@@ -1,0 +1,90 @@
+import useRoles from '../../modules/roles/useRoles'
+import { useDeleteRoleMutation } from '../../modules/roles/rolesApi'
+import { DataGrid } from '@mui/x-data-grid'
+import { Button, Stack, Box, IconButton } from '@mui/material'
+import { useNavigate } from 'react-router-dom'
+import AddIcon from '@mui/icons-material/Add'
+import EditIcon from '@mui/icons-material/Edit'
+import DeleteIcon from '@mui/icons-material/Delete'
+import Visibility from '@mui/icons-material/Visibility'
+import { useTranslation } from 'react-i18next'
+
+export default function RolesList () {
+  const { roles, isLoading, refetch } = useRoles()
+  const [deleteRole] = useDeleteRoleMutation()
+  const nav = useNavigate()
+  const { t } = useTranslation()
+
+  const columns = [
+    { field: 'id', headerName: 'ID', width: 70 },
+    { field: 'name', headerName: t('role.name', 'Name'), flex: 1 },
+    {
+      field: 'actions',
+      headerName: t('table.actions', 'Actions'),
+      width: 150,
+      renderCell: (params) => (
+        <Box>
+          <IconButton color="info" onClick={() => nav(`/roles/${params.row.id}`)}>
+            <Visibility />
+          </IconButton>
+          <IconButton color="primary" onClick={() => nav(`/roles/${params.row.id}/edit`)}>
+            <EditIcon />
+          </IconButton>
+          <IconButton
+            color="error"
+            onClick={async () => {
+              if (window.confirm(t('confirm.delete', 'Supprimer ?'))) {
+                await deleteRole(params.row.id)
+                refetch()
+              }
+            }}
+          >
+            <DeleteIcon />
+          </IconButton>
+        </Box>
+      )
+    }
+  ]
+
+  return (
+    <Stack spacing={2}>
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 1 }}>
+        <Button
+          variant="contained"
+          color="primary"
+          startIcon={<AddIcon />}
+          sx={{ borderRadius: 3, fontWeight: 600, fontSize: 16, px: 3 }}
+          onClick={() => nav('/roles/create')}
+        >
+          {t('button.add_role', 'Add')}
+        </Button>
+      </Box>
+      <Box
+        sx={{
+          height: 500,
+          background: '#fff',
+          borderRadius: 2,
+          p: 2,
+          width: '100%',
+          minWidth: 0,
+          overflowX: 'auto'
+        }}
+      >
+        <DataGrid
+          rows={roles}
+          columns={columns}
+          loading={isLoading}
+          pageSize={10}
+          rowsPerPageOptions={[5, 10, 20, 100]}
+          getRowId={row => row.id}
+          disableSelectionOnClick
+          sx={{
+            width: '100%',
+            minWidth: 600,
+            '& .MuiDataGrid-cell': { whiteSpace: 'normal', wordBreak: 'break-word' }
+          }}
+        />
+      </Box>
+    </Stack>
+  )
+}

--- a/src/pages/users/UserForm.jsx
+++ b/src/pages/users/UserForm.jsx
@@ -8,6 +8,7 @@ import { useParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import PhotoUploader from '../../components/PhotoUploader'
 import { useUploadImageMutation } from '../../modules/users/usersApi'
+import useRoles from '../../modules/roles/useRoles'
 
 export default function UserForm () {
   const { id } = useParams()
@@ -23,13 +24,7 @@ export default function UserForm () {
     }
   }, [data, reset])
 
-  // Les rôles doivent venir de l'API ou être hardcodés temporairement
-  const roles = [
-    { value: 'super_admin', label: 'Super Admin' },
-    { value: 'admin', label: 'Admin' },
-    { value: 'manager', label: 'Manager' },
-    { value: 'user', label: 'Utilisateur' }
-  ]
+  const { roles = [] } = useRoles()
 
   // Soumission avec feedback
   const onSubmit = async (values) => {
@@ -113,7 +108,9 @@ export default function UserForm () {
               value={field.value ?? []}
             >
               {roles.map(opt =>
-                <MenuItem key={opt.value} value={opt.value}>{opt.label}</MenuItem>
+                <MenuItem key={opt.id || opt.value} value={opt.name || opt.value}>
+                  {opt.label || opt.name}
+                </MenuItem>
               )}
             </TextField>
           )}

--- a/src/routes/adminRoutes.jsx
+++ b/src/routes/adminRoutes.jsx
@@ -11,6 +11,11 @@ import UserForm from '../pages/users/UserForm'
 import ProvidersList from '../pages/provider/ProvidersList'
 import ProviderForm from '../pages/provider/ProviderForm'
 import ProviderDetails from '../pages/provider/ProviderDetails'
+import RolesList from '../pages/roles/RolesList'
+import RoleForm from '../pages/roles/RoleForm'
+import RoleDetails from '../pages/roles/RoleDetails'
+import PermissionsList from '../pages/roles/PermissionsList'
+import PermissionForm from '../pages/roles/PermissionForm'
 
 export default [
   {
@@ -30,9 +35,9 @@ export default [
         children: [
           { index: true, element: <AnimalsList /> },
           { path: 'create', element: <AnimalForm /> },
-          { path: ':id/edit', element: <AnimalForm /> },
-          { path: ':id', element: <AnimalDetails /> },
-        ]
+        { path: ':id/edit', element: <AnimalForm /> },
+        { path: ':id', element: <AnimalDetails /> },
+      ]
       },
       {
         path: 'providers',
@@ -41,6 +46,23 @@ export default [
           { path: 'create', element: <ProviderForm /> },
           { path: ':id/edit', element: <ProviderForm /> },
           { path: ':id', element: <ProviderDetails /> }
+        ]
+      },
+      {
+        path: 'roles',
+        children: [
+          { index: true, element: <RolesList /> },
+          { path: 'create', element: <RoleForm /> },
+          { path: ':id/edit', element: <RoleForm /> },
+          { path: ':id', element: <RoleDetails /> }
+        ]
+      },
+      {
+        path: 'permissions',
+        children: [
+          { index: true, element: <PermissionsList /> },
+          { path: 'create', element: <PermissionForm /> },
+          { path: ':id/edit', element: <PermissionForm /> }
         ]
       },
       {


### PR DESCRIPTION
## Summary
- implement rolesApi with endpoints for roles and permissions
- create hooks for roles and permissions
- add CRUD pages for roles and permissions
- integrate module into router, store and menu
- allow user form to load roles from API
- update translations and documentation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684416adbd108333be80271e0c003a07