### PR TITLE
Add booking locale entries

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -37,7 +37,8 @@
     "permissions": "Permissions",
     "collars": "Collars",
     "categories": "Categories",
-    "my_services": "My Services"
+    "my_services": "My Services",
+    "my_bookings": "My Bookings"
   },
   "roles": {
     "super_admin": "Super Admin",
@@ -125,6 +126,24 @@
     "edit_title": "Edit permission",
     "save_error": "Save error",
     "name": "Name"
+  },
+  "booking": {
+    "add_title": "New booking",
+    "edit_title": "Edit booking",
+    "animal": "Animal",
+    "user": "User",
+    "service": "Service",
+    "provider": "Provider",
+    "date": "Date",
+    "time": "Time",
+    "payment_status": "Payment",
+    "payment_intent": "Payment intent",
+    "currency": "Currency",
+    "details": "View details",
+    "calendar": "Booking Calendar",
+    "untitled": "Booking",
+    "saved": "Saved!",
+    "save_error": "Save error"
   },
   "provider_service": {
     "price": "Price",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -38,7 +38,8 @@
     "permissions": "Permissions",
     "collars": "Colliers",
     "categories": "Catégories",
-    "my_services": "Mes services"
+    "my_services": "Mes services",
+    "my_bookings": "Mes réservations"
   },
   "roles": {
     "super_admin": "Super Administrateur",
@@ -130,6 +131,24 @@
     "edit_title": "Modifier la permission",
     "save_error": "Erreur lors de l'enregistrement",
     "name": "Nom"
+  },
+  "booking": {
+    "add_title": "Ajouter une réservation",
+    "edit_title": "Modifier une réservation",
+    "animal": "Animal",
+    "user": "Utilisateur",
+    "service": "Service",
+    "provider": "Prestataire",
+    "date": "Date",
+    "time": "Heure",
+    "payment_status": "Paiement",
+    "payment_intent": "Intent de paiement",
+    "currency": "Devise",
+    "details": "Voir le détail",
+    "calendar": "Agenda des réservations",
+    "untitled": "Réservation",
+    "saved": "Réservation enregistrée !",
+    "save_error": "Erreur lors de l'enregistrement"
   },
   "provider_service": {
     "price": "Prix",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -38,7 +38,8 @@
     "permissions": "Permessi",
     "collars": "Collari",
     "categories": "Categorie",
-    "my_services": "I miei servizi"
+    "my_services": "I miei servizi",
+    "my_bookings": "Le mie prenotazioni"
   },
   "roles": {
     "super_admin": "Super Amministratore",
@@ -126,6 +127,24 @@
     "edit_title": "Modifica permesso",
     "save_error": "Errore di salvataggio",
     "name": "Nome"
+  },
+  "booking": {
+    "add_title": "Nuova prenotazione",
+    "edit_title": "Modifica prenotazione",
+    "animal": "Animale",
+    "user": "Utente",
+    "service": "Servizio",
+    "provider": "Fornitore",
+    "date": "Data",
+    "time": "Ora",
+    "payment_status": "Pagamento",
+    "payment_intent": "Intento di pagamento",
+    "currency": "Valuta",
+    "details": "Vedi dettagli",
+    "calendar": "Calendario prenotazioni",
+    "untitled": "Prenotazione",
+    "saved": "Prenotazione salvata!",
+    "save_error": "Errore di salvataggio"
   },
   "provider_service": {
     "price": "Prezzo",


### PR DESCRIPTION
## Summary
- add `my_bookings` page label across locales
- translate booking section for en, fr and it

## Testing
- `jq '.' src/locales/en.json`
- `jq '.' src/locales/fr.json`
- `jq '.' src/locales/it.json`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684eef44c1b88333bf4c721b36cd5811