### PR TITLE
Add provider bookings page

### DIFF
--- a/src/layouts/MainLayout.jsx
+++ b/src/layouts/MainLayout.jsx
@@ -38,7 +38,15 @@ export default function MainLayout() {
 
   const servicesPath = is('super_admin') || is('admin')
   ? '/services'
-  : '/my-services'  
+  : '/my-services'
+
+  const bookingsLabel = is('super_admin') || is('admin')
+    ? t('page.bookings', 'Bookings')
+    : t('page.my_bookings', 'My Bookings')
+
+  const bookingsPath = is('super_admin') || is('admin')
+    ? '/bookings'
+    : '/my-bookings'
 
   const menu = [
     { label: 'Dashboard', path: '/', icon: <DashboardIcon /> },
@@ -50,7 +58,7 @@ export default function MainLayout() {
     { label: 'Categories', path: '/categories', icon: <CategoryIcon />, permissions: ['view_any_category', 'view_own_category'] },
     { label: 'Roles', path: '/roles', icon: <PeopleIcon />, roles: ['super_admin'] },
     { label: 'Permissions', path: '/permissions', icon: <BusinessIcon />, roles: ['super_admin'] },
-    { label: 'Bookings', path: '/bookings', icon: <ScheduleIcon />, permissions: ['view_any_booking', 'view_own_booking'] }
+    { label: bookingsLabel, path: bookingsPath, icon: <ScheduleIcon />, permissions: ['view_any_booking', 'view_own_booking'] }
   ]
 
   const allowedMenu = useMemo(
@@ -72,6 +80,7 @@ const pageTitles = {
   '/roles': t('page.roles', 'Roles'),
   '/permissions': t('page.permissions', 'Permissions'),
   '/bookings': t('page.bookings', 'Bookings'),
+  '/my-bookings': t('page.my_bookings', 'My Bookings'),
 }
 
 const pageTitle = pageTitles[pathname] || 'MyPetly Admin'

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -37,7 +37,9 @@
     "permissions": "Permissions",
     "collars": "Collars",
     "categories": "Categories",
-    "my_services": "My Services"
+    "my_services": "My Services",
+    "bookings": "Bookings",
+    "my_bookings": "My Bookings"
   },
   "roles": {
     "super_admin": "Super Admin",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -38,7 +38,9 @@
     "permissions": "Permissions",
     "collars": "Colliers",
     "categories": "Catégories",
-    "my_services": "Mes services"
+    "my_services": "Mes services",
+    "bookings": "Réservations",
+    "my_bookings": "Mes réservations"
   },
   "roles": {
     "super_admin": "Super Administrateur",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -38,7 +38,9 @@
     "permissions": "Permessi",
     "collars": "Collari",
     "categories": "Categorie",
-    "my_services": "I miei servizi"
+    "my_services": "I miei servizi",
+    "bookings": "Prenotazioni",
+    "my_bookings": "Le mie prenotazioni"
   },
   "roles": {
     "super_admin": "Super Amministratore",

--- a/src/modules/bookings/bookingsApi.js
+++ b/src/modules/bookings/bookingsApi.js
@@ -7,7 +7,10 @@ export const bookingsApi = createApi({
   tagTypes: ['Booking'],
   endpoints: (b) => ({
     listBookings: b.query({
-      query: () => 'bookings',
+      query: (params) => {
+        const query = params ? `?${new URLSearchParams(params).toString()}` : ''
+        return `bookings${query}`
+      },
       providesTags: ['Booking']
     }),
     getBooking: b.query({

--- a/src/modules/bookings/useBookings.js
+++ b/src/modules/bookings/useBookings.js
@@ -1,6 +1,6 @@
 import { useListBookingsQuery } from './bookingsApi'
 
-export default function useBookings() {
-  const { data = [], isLoading, error, refetch } = useListBookingsQuery()
+export default function useBookings(params) {
+  const { data = [], isLoading, error, refetch } = useListBookingsQuery(params)
   return { bookings: data, isLoading, error, refetch }
 }

--- a/src/pages/bookings/MyBookingsList.jsx
+++ b/src/pages/bookings/MyBookingsList.jsx
@@ -1,0 +1,111 @@
+import useBookings from '../../modules/bookings/useBookings'
+import { useUpdateBookingMutation } from '../../modules/bookings/bookingsApi'
+import useOwnProviderId from '../../modules/provider/useOwnProviderId'
+import { DataGrid } from '@mui/x-data-grid'
+import { Stack, Box, IconButton } from '@mui/material'
+import VisibilityIcon from '@mui/icons-material/Visibility'
+import CheckCircleRoundedIcon from '@mui/icons-material/CheckCircleRounded'
+import CancelRoundedIcon from '@mui/icons-material/CancelRounded'
+import DoneAllIcon from '@mui/icons-material/DoneAll'
+import { useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+
+export default function MyBookingsList() {
+  const providerId = useOwnProviderId()
+  const { bookings, isLoading, refetch } = useBookings({ provider_id: providerId })
+  const [updateBooking] = useUpdateBookingMutation()
+  const nav = useNavigate()
+  const { t } = useTranslation()
+
+  const handleStatus = async (id, status) => {
+    await updateBooking({ id, status })
+    refetch()
+  }
+
+  const columns = [
+    { field: 'id', headerName: 'ID', width: 70 },
+    {
+      field: 'animalName',
+      headerName: t('booking.animal', 'Animal'),
+      flex: 1,
+      valueGetter: (value, row) => {
+        const a = row?.animal
+        if (!a) return '-'
+        return typeof a.name === 'object'
+          ? a.name.fr ?? a.name.en ?? Object.values(a.name)[0] ?? '-'
+          : a.name ?? '-'
+      }
+    },
+    {
+      field: 'serviceName',
+      headerName: t('booking.service', 'Service'),
+      flex: 1,
+      valueGetter: (value, row) => {
+        const s = row?.service
+        if (!s) return '-'
+        return typeof s.name === 'object'
+          ? s.name.fr ?? s.name.en ?? Object.values(s.name)[0] ?? '-'
+          : s.name ?? '-'
+      }
+    },
+    {
+      field: 'appointment_date',
+      headerName: t('booking.date', 'Date'),
+      flex: 1,
+      valueFormatter: value => {
+        if (!value) return '-'
+        const date = new Date(value)
+        return date.toLocaleDateString('fr-FR')
+      }
+    },
+    { field: 'time', headerName: t('booking.time', 'Heure'), flex: 1 },
+    { field: 'status', headerName: t('booking.status', 'Statut'), flex: 1 },
+    {
+      field: 'actions',
+      headerName: t('table.actions', 'Actions'),
+      width: 180,
+      renderCell: params => {
+        const s = params.row.status
+        return (
+          <Box>
+            <IconButton color="info" onClick={() => nav(`/bookings/${params.row.id}`)}>
+              <VisibilityIcon />
+            </IconButton>
+            {(s === 'upcoming' || s === 'pending') && (
+              <>
+                <IconButton color="success" onClick={() => handleStatus(params.row.id, 'confirmed')}>
+                  <CheckCircleRoundedIcon />
+                </IconButton>
+                <IconButton color="error" onClick={() => handleStatus(params.row.id, 'cancelled')}>
+                  <CancelRoundedIcon />
+                </IconButton>
+              </>
+            )}
+            {s === 'confirmed' && (
+              <IconButton color="primary" onClick={() => handleStatus(params.row.id, 'finished')}>
+                <DoneAllIcon />
+              </IconButton>
+            )}
+          </Box>
+        )
+      }
+    }
+  ]
+
+  return (
+    <Stack spacing={2}>
+      <Box sx={{ height: 500, background: '#fff', borderRadius: 2, p: 2, width: '100%', minWidth: 0, overflowX: 'auto' }}>
+        <DataGrid
+          rows={bookings}
+          columns={columns}
+          loading={isLoading}
+          pageSize={10}
+          rowsPerPageOptions={[5, 10, 20, 100]}
+          getRowId={row => row.id}
+          disableSelectionOnClick
+          sx={{ width: '100%', minWidth: 900, '& .MuiDataGrid-cell': { whiteSpace: 'normal', wordBreak: 'break-word' } }}
+        />
+      </Box>
+    </Stack>
+  )
+}

--- a/src/routes/adminRoutes.jsx
+++ b/src/routes/adminRoutes.jsx
@@ -30,6 +30,7 @@ import BookingsList from '../pages/bookings/BookingsList'
 import BookingForm from '../pages/bookings/BookingForm'
 import BookingDetails from '../pages/bookings/BookingDetails'
 import BookingCalendar from '../pages/bookings/BookingCalendar'
+import MyBookingsList from '../pages/bookings/MyBookingsList'
 import CollarsList from '../pages/collar/CollarsList'
 import CollarForm from '../pages/collar/CollarForm'
 import CollarDetails from '../pages/collar/CollarDetails'
@@ -157,6 +158,10 @@ export default [
       {
   path: 'my-services',
   element: <RequirePerm allowed="view_own_provider_service"><MyServicesList /></RequirePerm>
+},
+{
+  path: 'my-bookings',
+  element: <RequirePerm allowed="view_own_booking"><MyBookingsList /></RequirePerm>
 },
 
       {


### PR DESCRIPTION
## Summary
- allow bookings API to filter by parameters
- support fetching bookings with params
- implement `MyBookingsList` page for providers
- add new i18n keys and routing
- update main menu to show **My Bookings**

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684eef4110e88333a25349bec399a42f